### PR TITLE
Option names starting with "h" get parsed incorrectly

### DIFF
--- a/R/flagr.R
+++ b/R/flagr.R
@@ -65,7 +65,7 @@ flagr <- function(program_name = regmatches(getwd(),
   }
   
   parse <- function() {
-    if (!is.null(extract_flag("h|(help)"))) return(help())
+    if (!is.null(extract_flag("^(h|(help))$"))) return(help())
   }
   
   help <- function() {


### PR DESCRIPTION
This branch fixes an issue that's encountered when trying to parse an option whose name starts with the letter "h", e.g. "host". The parser would incorrectly interpret such an option as requesting help.

This branch resolves this issue by checking for the beginning of token (`^`) and end of token (`$`) characters within each option name, so that `host` can't get interpreted as `h|(help)`.