### PR TITLE
Help Won't Come

### DIFF
--- a/R/flagr.R
+++ b/R/flagr.R
@@ -65,7 +65,7 @@ flagr <- function(program_name = regmatches(getwd(),
   }
   
   parse <- function() {
-    if (!is.null(extract_flag("^(h|(help))$"))) return(help())
+    if (!is.null(extract_flag("(h|(help))$"))) return(help())
   }
   
   help <- function() {


### PR DESCRIPTION
We've all been there. We ask for help, and it doesn't come.

This branch fixes a bug introduced by [the last bug fix](https://github.com/daniel-salmon/flagr/pull/1): The parser would look for the *start of line character* in addition to the end of line character when attempting to match a flag against the set of flags. The issue is that the set of flags recognized by the parser *can't* have the start of line character because it strips `^-(-)?` from each command line argument to match against the flag names.

So this retains the end of line character (`$`) so that help will only be invoked when the full flag expression is "h" or "help"; "host" still won't get parsed as help since `host$` doesn't match `(h|(help))$`.